### PR TITLE
Put functions into a separate linked function

### DIFF
--- a/azuredeploy.template.json
+++ b/azuredeploy.template.json
@@ -20,9 +20,6 @@
       "minLength": 8,
       "maxLength": 128
     },
-    "functionsName": {
-      "type": "string"
-    },
     "apiName": {
       "type": "string"
     }
@@ -31,7 +28,6 @@
     "rawUrl": "https://raw.githubusercontent.com/IFRCGo/go-infrastructure/",
     "baseTemplateUrl": "[concat(variables('rawUrl'), parameters('gitBranch'), '/')]",
     "pgsqlTemplate": "[concat(variables('baseTemplateUrl'), 'postgresql/template.json')]",
-    "functionsTemplate": "[concat(variables('baseTemplateUrl'), 'functions/template.json')]",
     "apiTemplate": "[concat(variables('baseTemplateUrl'), 'api/template.json')]"
   },
   "resources": [{
@@ -53,22 +49,6 @@
         },
         "administratorLoginPassword": {
           "value": "[parameters('dbAdministratorLoginPassword')]"
-        }
-      }
-    }
-  }, {
-    "apiVersion": "2017-05-10",
-    "name": "linkedFunctionsTemplate",
-    "type": "Microsoft.Resources/deployments",
-    "properties": {
-      "mode": "incremental",
-      "templateLink": {
-        "uri": "[variables('functionsTemplate')]",
-        "contentVersion": "1.0.0.0"
-      },
-      "parameters": {
-        "appName": {
-          "value": "[parameters('functionsName')]"
         }
       }
     }

--- a/functions.template.json
+++ b/functions.template.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "functionsName": {
+      "type": "string"
+    },
+  },
+  "variables": {
+    "rawUrl": "https://raw.githubusercontent.com/IFRCGo/go-infrastructure/",
+    "baseTemplateUrl": "[concat(variables('rawUrl'), parameters('gitBranch'), '/')]",
+    "functionsTemplate": "[concat(variables('baseTemplateUrl'), 'functions/template.json')]"
+  },
+  "resources": [{
+    "apiVersion": "2017-05-10",
+    "name": "linkedFunctionsTemplate",
+    "type": "Microsoft.Resources/deployments",
+    "properties": {
+      "mode": "incremental",
+      "templateLink": {
+        "uri": "[variables('functionsTemplate')]",
+        "contentVersion": "1.0.0.0"
+      },
+      "parameters": {
+        "appName": {
+          "value": "[parameters('functionsName')]"
+        }
+      }
+    }
+  }]
+}


### PR DESCRIPTION
We actually shouldn't keep the functions in the deployment template. The functions app is already deployed and updates on merges to `go-functions`, and redeploying can actually cause problems.